### PR TITLE
Remove confusing error binding

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -2,7 +2,7 @@
 var self = this || /* istanbul ignore next */ {};
 try {
   self.EventTarget = (new EventTarget).constructor;
-} catch(EventTarget) {
+} catch(_error) {
   (function (Object, wm) {
     var create = Object.create;
     var defineProperty = Object.defineProperty;

--- a/esm/index.js
+++ b/esm/index.js
@@ -2,7 +2,7 @@
 var self = this || /* istanbul ignore next */ {};
 try {
   self.EventTarget = (new EventTarget).constructor;
-} catch(EventTarget) {
+} catch(_error) {
   (function (Object, wm) {
     var create = Object.create;
     var defineProperty = Object.defineProperty;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var self = this || /* istanbul ignore next */ {};
 try {
   self.EventTarget = (new EventTarget).constructor;
-} catch(EventTarget) {
+} catch(_error) {
   (function (Object, wm) {
     var create = Object.create;
     var defineProperty = Object.defineProperty;


### PR DESCRIPTION
The top of the code seem to suggest that we are extending the error thrown by `self.EventTarget = (new EventTarget).constructor`. This changes makes it clearer that this error is unused.