### PR TITLE
Add typescript types declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default EventTarget;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An EventTarget polyfill",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
+  "types": "./index.d.ts",
   "unpkg": "min.js",
   "scripts": {
     "build": "npm run cjs && npm run esm && npm run min && npm run test && npm run size",


### PR DESCRIPTION
I use this project many times in a few of my TS projects.
I got tired of declaring this as `any` via a simple `declare module "@ungap/event-target"`.

My goal with this change is to declare this module effectively as an "alias" of the [`interface EventTarget`](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L5410) of the built-in `lib.dom.d.ts`