### PR TITLE
[package.json] add types in exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/ungap/event-target#readme",
   "type": "module",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./esm/index.js",
     "default": "./cjs/index.js"
   }


### PR DESCRIPTION
Starting from TS 4.7 ([see release note](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)), we need to add a `types` field in the `exports` object when then path to the `.d.ts` file doesn’t match the file exposed.

If it isn’t set, we have the following error:

```
… error TS7016: Could not find a declaration file for module '@ungap/event-target'. '…/node_modules/@ungap/event-target/esm/index.js' implicitly has an 'any' type.
  There are types at '…/node_modules/@ungap/event-target/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@ungap/event-target' library may need to update its package.json or typings.
```

This should fix it by adding the same `types` as top level, but within the `exports` object